### PR TITLE
[BE] 자동 배포 스크립트 수정 및 크론탭 설정 정보 추가

### DIFF
--- a/backend/deploy/back_deploy.sh
+++ b/backend/deploy/back_deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+export MYSQL_DATABASE_URL=""
+export MYSQL_DATABASE_USERNAME=""
+export MYSQL_DATABASE_PASSWORD=""
+
 cd back_sidedish/backend
 
 git fetch
@@ -22,4 +26,4 @@ rm -rf build
 git merge origin/backend
 ./gradlew bootJar
 
-nohup java -jar build/libs/sidedish-0.0.1-SNAPSHOT.jar &
+nohup java -jar build/libs/sidedish-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod &

--- a/backend/deploy/crontab_config.sh
+++ b/backend/deploy/crontab_config.sh
@@ -1,0 +1,7 @@
+# back script - At every 3rd minute
+*/3 * * * * /home/ubuntu/back_deploy.sh >> log/back_log.txt 2>&1
+
+# front script - At every 3rd minute
+*/3 * * * * /home/ubuntu/front_deploy.sh >> log/front_log.txt 2>&1
+
+

--- a/backend/deploy/front_deploy.sh
+++ b/backend/deploy/front_deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd front_sidedish
+echo "[FE] Start script"
 
 git fetch
 remote=` git rev-parse origin/frontend`
@@ -19,4 +20,7 @@ git pull origin frontend
 
 echo "[FE] project rebuild"
 cd frontend/sidedish
+
+npm install
+
 npm run build


### PR DESCRIPTION
## 🤷‍♂️ Description

- 자동 배포 스크립트의 오류를 수정하고 3분에 한 번씩 crontab을 통해 자동 배포를 진행했습니다.
- 자동배포 쉘 스크립트로 생성되는 log 정보는 log 디렉토리에 `back_log.txt`, `front_log.txt`에 각각 저장됩니다.


## 📝 Primary Commits

- [X] `front_deploy.sh`, `back_deploy.sh` 쉘 스크립트 수정
- [X] `crontab_config.sh` 크론탭 설정 정보 기입
- [X] 자동 배포

## 📷 Screenshots

<img width="290" alt="image" src="https://user-images.githubusercontent.com/67811880/164960879-4f3d63d6-fc0a-43f2-a4c7-af6e3e9183e7.png">

<img width="387" alt="image" src="https://user-images.githubusercontent.com/67811880/164960956-e343ffef-7d7c-4144-be00-e9b4548bb37c.png">



<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
