### PR TITLE
[FE] small-sidedish 슬라이드 이벤트

### DIFF
--- a/frontend/sidedish/src/utils.js
+++ b/frontend/sidedish/src/utils.js
@@ -1,9 +1,9 @@
-export const getData = async (url, callback) => {
+export const getData = async (url) => {
     const response = await fetch(url);
     if (!response.ok) {
         throw Error(response.statusText);
     }
 
     const data = await response.json();
-    callback(data);
+    return data;
 };

--- a/frontend/sidedish/src/view/sidedish/BigSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/BigSidedish.jsx
@@ -19,9 +19,8 @@ function BigSidedish() {
 
     useEffect(() => {
         try {
-            getData(
-                API.FESTIVAL + "한-번-주문하면-두-번-반하는-반찬",
-                setBigSidedishData
+            getData(API.FESTIVAL + "한-번-주문하면-두-번-반하는-반찬").then(
+                (data) => setBigSidedishData(data)
             );
         } catch (error) {
             console.error(error);

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -4,6 +4,7 @@ import { Container, Title } from "./Sidedish.style";
 import { API } from "../../config";
 import SidedishCards from "./SidedishCards";
 import { getData } from "../../utils";
+import { CarouselItem, Carousel } from "./carousel/Carousel";
 
 const theme = {
     size: "small",
@@ -20,7 +21,11 @@ function SmallSidedish({ isVisible, section, title }) {
         }
     }, [section]);
 
-    if (!isVisible || !items) {
+    if (!isVisible) {
+        return;
+    }
+
+    if (!items) {
         return;
     }
 
@@ -28,7 +33,11 @@ function SmallSidedish({ isVisible, section, title }) {
         <ThemeProvider theme={theme}>
             <Container>
                 <Title>{title}</Title>
-                <SidedishCards dishes={items.data}></SidedishCards>
+                <Carousel>
+                    <CarouselItem>
+                        <SidedishCards dishes={items.data}></SidedishCards>
+                    </CarouselItem>
+                </Carousel>
             </Container>
         </ThemeProvider>
     );

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -11,28 +11,54 @@ const theme = {
 };
 
 function SmallSidedish({ isVisible, section, title }) {
-    const [items, setItems] = useState(null);
+    const [smallSidedishes, setSmallSidedishes] = useState(null);
     const [page, setPage] = useState(1);
+    const [lastCachedPage, setLastPage] = useState(0);
+    const [hasNext, sethasNextValue] = useState(null);
 
     useEffect(() => {
         try {
-            getData(API.DISH_SECTION + section + "&page=" + page, setItems);
+            if (lastCachedPage < page) {
+                getData(API.DISH_SECTION + section + "&page=" + page).then(
+                    (data) => {
+                        if (page === 1) {
+                            setSmallSidedishes(data.data);
+                        } else {
+                            setSmallSidedishes([
+                                ...smallSidedishes,
+                                ...data.data,
+                            ]);
+                        }
+                        setLastPage(page);
+                        sethasNextValue(data.hasNext);
+                    }
+                );
+            }
         } catch (error) {
             console.error(error);
         }
-    }, [section, page]);
+    }, [section, smallSidedishes, page, lastCachedPage]);
 
     if (!isVisible) {
         return;
     }
 
-    if (!items) {
+    if (!smallSidedishes) {
         return;
     }
 
     const onUpdatePage = (newPage) => {
         setPage(newPage);
     };
+
+    const getCurrSmallSidedishes = () => {
+        if (4 * page >= smallSidedishes.length) {
+            return smallSidedishes.slice(smallSidedishes.length - 4);
+        }
+        return smallSidedishes.slice(4 * (page - 1), 4 * page);
+    };
+
+    const currSmallSidedishes = getCurrSmallSidedishes();
 
     return (
         <ThemeProvider theme={theme}>
@@ -41,9 +67,9 @@ function SmallSidedish({ isVisible, section, title }) {
                 <Carousel
                     page={page}
                     onUpdatePage={onUpdatePage}
-                    hasNext={items.hasNext}
+                    hasNext={hasNext}
                 >
-                    <SidedishCards dishes={items.data}></SidedishCards>
+                    <SidedishCards dishes={currSmallSidedishes}></SidedishCards>
                 </Carousel>
             </Container>
         </ThemeProvider>

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -4,7 +4,7 @@ import { Container, Title } from "./Sidedish.style";
 import { API } from "../../config";
 import SidedishCards from "./SidedishCards";
 import { getData } from "../../utils";
-import { CarouselItem, Carousel } from "./carousel/Carousel";
+import { Carousel } from "./carousel/Carousel";
 
 const theme = {
     size: "small",
@@ -30,8 +30,8 @@ function SmallSidedish({ isVisible, section, title }) {
         return;
     }
 
-    const onClickRightBtn = (curPage) => {
-        setPage(curPage + 1);
+    const onUpdatePage = (newPage) => {
+        setPage(newPage);
     };
 
     return (
@@ -40,12 +40,10 @@ function SmallSidedish({ isVisible, section, title }) {
                 <Title>{title}</Title>
                 <Carousel
                     page={page}
-                    onClickRightBtn={onClickRightBtn}
+                    onUpdatePage={onUpdatePage}
                     hasNext={items.hasNext}
                 >
-                    <CarouselItem>
-                        <SidedishCards dishes={items.data}></SidedishCards>
-                    </CarouselItem>
+                    <SidedishCards dishes={items.data}></SidedishCards>
                 </Carousel>
             </Container>
         </ThemeProvider>

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -12,14 +12,15 @@ const theme = {
 
 function SmallSidedish({ isVisible, section, title }) {
     const [items, setItems] = useState(null);
+    const [page, setPage] = useState(1);
 
     useEffect(() => {
         try {
-            getData(API.DISH_SECTION + section, setItems);
+            getData(API.DISH_SECTION + section + "&page=" + page, setItems);
         } catch (error) {
             console.error(error);
         }
-    }, [section]);
+    }, [section, page]);
 
     if (!isVisible) {
         return;
@@ -29,11 +30,19 @@ function SmallSidedish({ isVisible, section, title }) {
         return;
     }
 
+    const onClickRightBtn = (curPage) => {
+        setPage(curPage + 1);
+    };
+
     return (
         <ThemeProvider theme={theme}>
             <Container>
                 <Title>{title}</Title>
-                <Carousel>
+                <Carousel
+                    page={page}
+                    onClickRightBtn={onClickRightBtn}
+                    hasNext={items.hasNext}
+                >
                     <CarouselItem>
                         <SidedishCards dishes={items.data}></SidedishCards>
                     </CarouselItem>

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -67,6 +67,7 @@ function SmallSidedish({ isVisible, section, title }) {
                 <Carousel
                     page={page}
                     onUpdatePage={onUpdatePage}
+                    currDataSize={smallSidedishes.length}
                     hasNext={hasNext}
                 >
                     <SidedishCards dishes={currSmallSidedishes}></SidedishCards>

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useState } from "react";
+import { Container, CarouselItems, Icon } from "./Carousel.style";
+
+function Carousel({ children }) {
+    const [activeIndex, setActiveIndex] = useState(0);
+    const updateIndex = (newIndex) => {
+        if (newIndex < 0) {
+            newIndex = 0;
+        } else if (newIndex >= React.Children.count(children)) {
+            newIndex = React.Children.count(children) - 1;
+        }
+
+        setActiveIndex(newIndex);
+    };
+    return (
+        <Container>
+            <Icon
+                onClick={() => {
+                    updateIndex(activeIndex - 1);
+                }}
+                className="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+            >
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15 19l-7-7 7-7"
+                />
+            </Icon>
+            <CarouselItems
+                style={{ transform: `translateX(-${activeIndex * 100}%)` }}
+            >
+                {React.Children.map(children, (child) => {
+                    return React.cloneElement(child, { width: "100%" });
+                })}
+            </CarouselItems>
+            <Icon
+                onClick={() => {
+                    updateIndex(activeIndex + 1);
+                }}
+                className="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+            >
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 5l7 7-7 7"
+                />
+            </Icon>
+        </Container>
+    );
+}
+
+function CarouselItem({ children }) {
+    return (
+        <div className="carousel-item" style={{ width: "100%" }}>
+            {children}
+        </div>
+    );
+}
+
+export { Carousel, CarouselItem };

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useState } from "react";
 import { Container, CarouselItems, Icon } from "./Carousel.style";
 
-function Carousel({ page, onClickRightBtn, hasNext, children }) {
+function Carousel({ page, onUpdatePage, hasNext, children }) {
     const [activeIndex, setActiveIndex] = useState(0);
     const updateIndex = (newIndex) => {
         if (newIndex < 0) {
@@ -18,8 +18,12 @@ function Carousel({ page, onClickRightBtn, hasNext, children }) {
         <Container>
             <Icon
                 onClick={() => {
-                    updateIndex(activeIndex - 1);
+                    if (page - 1 !== 0) {
+                        updateIndex(activeIndex - 1);
+                        onUpdatePage(page - 1);
+                    }
                 }}
+                clickable={page > 1}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -44,10 +48,10 @@ function Carousel({ page, onClickRightBtn, hasNext, children }) {
                 onClick={() => {
                     if (hasNext) {
                         updateIndex(activeIndex + 1);
-                        onClickRightBtn(page);
+                        onUpdatePage(page + 1);
                     }
                 }}
-                hasNext={hasNext}
+                clickable={hasNext}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -65,12 +69,4 @@ function Carousel({ page, onClickRightBtn, hasNext, children }) {
     );
 }
 
-function CarouselItem({ children }) {
-    return (
-        <div className="carousel-item" style={{ width: "100%" }}>
-            {children}
-        </div>
-    );
-}
-
-export { Carousel, CarouselItem };
+export { Carousel };

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useState } from "react";
-import { Container, Icon } from "./Carousel.style";
+import { Container, Icon, CarouselItem, Wrapper } from "./Carousel.style";
 
 const isClickable = (direction, params) => {
     if (direction === "R") {
@@ -11,30 +11,21 @@ const isClickable = (direction, params) => {
 };
 
 function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
-    const [activeIndex, setActiveIndex] = useState(0);
-    const updateIndex = (newIndex) => {
-        if (newIndex < 0) {
-            newIndex = 0;
-        } else if (newIndex >= React.Children.count(children)) {
-            newIndex = React.Children.count(children) - 1;
-        }
-
-        setActiveIndex(newIndex);
-    };
+    const [direction, setDirection] = useState(null);
 
     const onClick = (direction) => {
         switch (direction) {
             case "L": {
                 if (isClickable("L", { page })) {
-                    updateIndex(activeIndex - 1);
                     onUpdatePage(page - 1);
+                    setDirection("L");
                 }
                 break;
             }
             case "R": {
                 if (isClickable("R", { hasNext, page, currDataSize })) {
-                    updateIndex(activeIndex + 1);
                     onUpdatePage(page + 1);
+                    setDirection("R");
                 }
                 break;
             }
@@ -60,7 +51,9 @@ function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
                     d="M15 19l-7-7 7-7"
                 />
             </Icon>
-            <div>{children}</div>
+            <Wrapper>
+                <CarouselItem direction={direction}>{children}</CarouselItem>
+            </Wrapper>
             <Icon
                 onClick={() => onClick("R")}
                 clickable={isClickable("R", { hasNext, page, currDataSize })}

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -1,6 +1,14 @@
 import React from "react";
 import { useState } from "react";
-import { Container, CarouselItems, Icon } from "./Carousel.style";
+import { Container, Icon } from "./Carousel.style";
+
+const isClickable = (direction, params) => {
+    if (direction === "R") {
+        const { hasNext, page, currDataSize } = params;
+        return hasNext || 4 * page < currDataSize;
+    }
+    return params.page > 1;
+};
 
 function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
     const [activeIndex, setActiveIndex] = useState(0);
@@ -14,16 +22,31 @@ function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
         setActiveIndex(newIndex);
     };
 
+    const onClick = (direction) => {
+        switch (direction) {
+            case "L": {
+                if (isClickable("L", { page })) {
+                    updateIndex(activeIndex - 1);
+                    onUpdatePage(page - 1);
+                }
+                break;
+            }
+            case "R": {
+                if (isClickable("R", { hasNext, page, currDataSize })) {
+                    updateIndex(activeIndex + 1);
+                    onUpdatePage(page + 1);
+                }
+                break;
+            }
+            default:
+        }
+    };
+
     return (
         <Container>
             <Icon
-                onClick={() => {
-                    if (page - 1 !== 0) {
-                        updateIndex(activeIndex - 1);
-                        onUpdatePage(page - 1);
-                    }
-                }}
-                clickable={page > 1}
+                onClick={() => onClick("L")}
+                clickable={isClickable("L", { page })}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -37,21 +60,10 @@ function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
                     d="M15 19l-7-7 7-7"
                 />
             </Icon>
-            <CarouselItems
-                style={{ transform: `translateX(-${activeIndex * 100}%)` }}
-            >
-                {React.Children.map(children, (child) => {
-                    return React.cloneElement(child, { width: "100%" });
-                })}
-            </CarouselItems>
+            <div>{children}</div>
             <Icon
-                onClick={() => {
-                    if (hasNext || 4 * page < currDataSize) {
-                        updateIndex(activeIndex + 1);
-                        onUpdatePage(page + 1);
-                    }
-                }}
-                clickable={hasNext || 4 * page < currDataSize}
+                onClick={() => onClick("R")}
+                clickable={isClickable("R", { hasNext, page, currDataSize })}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useState } from "react";
 import { Container, CarouselItems, Icon } from "./Carousel.style";
 
-function Carousel({ children }) {
+function Carousel({ page, onClickRightBtn, hasNext, children }) {
     const [activeIndex, setActiveIndex] = useState(0);
     const updateIndex = (newIndex) => {
         if (newIndex < 0) {
@@ -13,6 +13,7 @@ function Carousel({ children }) {
 
         setActiveIndex(newIndex);
     };
+
     return (
         <Container>
             <Icon
@@ -41,8 +42,12 @@ function Carousel({ children }) {
             </CarouselItems>
             <Icon
                 onClick={() => {
-                    updateIndex(activeIndex + 1);
+                    if (hasNext) {
+                        updateIndex(activeIndex + 1);
+                        onClickRightBtn(page);
+                    }
                 }}
+                hasNext={hasNext}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useState } from "react";
 import { Container, CarouselItems, Icon } from "./Carousel.style";
 
-function Carousel({ page, onUpdatePage, hasNext, children }) {
+function Carousel({ page, onUpdatePage, currDataSize, hasNext, children }) {
     const [activeIndex, setActiveIndex] = useState(0);
     const updateIndex = (newIndex) => {
         if (newIndex < 0) {
@@ -46,12 +46,12 @@ function Carousel({ page, onUpdatePage, hasNext, children }) {
             </CarouselItems>
             <Icon
                 onClick={() => {
-                    if (hasNext) {
+                    if (hasNext || 4 * page < currDataSize) {
                         updateIndex(activeIndex + 1);
                         onUpdatePage(page + 1);
                     }
                 }}
-                clickable={hasNext}
+                clickable={hasNext || 4 * page < currDataSize}
                 className="icon"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
@@ -17,7 +17,7 @@ const Icon = styled.svg`
     color: #bcbcbc;
     &:active,
     &:hover {
-        color: ${(props) => (props.hasNext ? "#1b1b1b" : "#bcbcbc")};
+        color: ${(props) => (props.clickable ? "#1b1b1b" : "#bcbcbc")};
     }
 `;
 

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+const Container = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 36px;
+`;
+
+const CarouselItems = styled.div`
+    transition: transform 0.3s;
+`;
+
+const Icon = styled.svg`
+    width: 24px;
+    height: 24px;
+    color: #bcbcbc;
+`;
+
+export { Container, CarouselItems, Icon };

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
@@ -15,6 +15,10 @@ const Icon = styled.svg`
     width: 24px;
     height: 24px;
     color: #bcbcbc;
+    &:active,
+    &:hover {
+        color: ${(props) => (props.hasNext ? "#1b1b1b" : "#bcbcbc")};
+    }
 `;
 
 export { Container, CarouselItems, Icon };

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
@@ -7,10 +7,6 @@ const Container = styled.div`
     gap: 36px;
 `;
 
-const CarouselItems = styled.div`
-    transition: transform 0.3s;
-`;
-
 const Icon = styled.svg`
     width: 24px;
     height: 24px;
@@ -21,4 +17,4 @@ const Icon = styled.svg`
     }
 `;
 
-export { Container, CarouselItems, Icon };
+export { Container, Icon };

--- a/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
+++ b/frontend/sidedish/src/view/sidedish/carousel/Carousel.style.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 
 const Container = styled.div`
     display: flex;
@@ -17,4 +17,41 @@ const Icon = styled.svg`
     }
 `;
 
-export { Container, Icon };
+const slideLeft2Right = keyframes`
+    from {
+        margin-left: 640px;
+        opacity: 1;
+    }
+    to {
+        margin-left: 0px;
+        opacity: 1;
+    }
+`;
+
+const slideRight2Left = keyframes`
+    from {
+        margin-left: -640px;
+        opacity: 1;
+    }
+    to {
+        margin-left: 0px;
+        opacity: 1;
+    }
+`;
+
+const CarouselItem = styled.div`
+    animation: ${(props) =>
+            props.direction === "L"
+                ? slideLeft2Right
+                : props.direction === "R"
+                ? slideRight2Left
+                : "none"}
+        0.4s ease-out;
+`;
+
+const Wrapper = styled.div`
+    width: 1280px;
+    overflow: hidden;
+`;
+
+export { Container, Icon, CarouselItem, Wrapper };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "sidedish2",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## 🤷‍♂️ Description

small-sidedish 슬라이드 이벤트를 구현한다.
오른쪽 버튼을 클릭하면 다음 4가지 반찬이 보인다.
왼쪽 버튼을 클릭하면 이전 4가지 반찬이 보인다.
개수가 맞지 않을 경우 4개로 맞춰서 보이게 한다.
(ex. 반찬 개수가 5가지일 때, 첫 화면 1, 2, 3, 4 가 보이는 상황. 오른쪽 버튼을 클릭하면 2, 3, 4, 5가 보여야 한다)

## 📝 Primary Commits

 - [x] 오른쪽 버튼을 클릭하면 다음 4가지 반찬이 보인다.
 - [x] 왼쪽 버튼을 클릭하면 이전 4가지 반찬이 보인다.
 - [x] 항상 반찬이 4개가 보이도록 한다.
 - [x] 슬라이드 애니메이션 추가

## 📷 Screenshots

![슬라이드 이벤트](https://user-images.githubusercontent.com/62249058/165666164-bff14824-3a90-4de6-8472-ad973f6802f4.gif)
