### PR TITLE
[BE] 요리 다중 조회시 배송정보 포함 및 배송 정보 데이터 추가

### DIFF
--- a/backend/src/main/java/com/codesquad/sidedish/dish/dto/DishListResponse.java
+++ b/backend/src/main/java/com/codesquad/sidedish/dish/dto/DishListResponse.java
@@ -1,8 +1,10 @@
 package com.codesquad.sidedish.dish.dto;
 
 import com.codesquad.sidedish.dish.domain.Dish;
+import com.codesquad.sidedish.dish.domain.DishDelivery;
 import com.codesquad.sidedish.dish.domain.DishDiscount;
 import com.codesquad.sidedish.dish.domain.DishImage;
+import com.codesquad.sidedish.other.DeliveryPolicy;
 import com.codesquad.sidedish.other.DiscountPolicy;
 import java.util.List;
 import java.util.Set;
@@ -23,6 +25,7 @@ public class DishListResponse {
     private final Integer stock;
     private final String imagePath;
 
+    private final List<String> deliveries;
     private final List<String> discounts;
 
     public static DishListResponse from(Dish dish) {
@@ -34,6 +37,7 @@ public class DishListResponse {
             dish.getDiscountPrice(),
             dish.getStock(),
             toImagePath(dish.getImages()),
+            toDeliveryDetails(dish.getDeliveries()),
             toDiscountDetails(dish.getDiscounts())
         );
     }
@@ -44,6 +48,14 @@ public class DishListResponse {
             .map(DishImage::getImagePath)
             .findAny()
             .orElse("");
+    }
+
+    public static List<String> toDeliveryDetails(Set<DishDelivery> dishDeliveries) {
+        return dishDeliveries.stream()
+            .map(DishDelivery::getCode)
+            .map(DeliveryPolicy::from)
+            .map(DeliveryPolicy::getDetail)
+            .collect(Collectors.toList());
     }
 
     public static List<String> toDiscountDetails(Set<DishDiscount> dishDiscounts) {

--- a/backend/src/main/resources/oauth.properties
+++ b/backend/src/main/resources/oauth.properties
@@ -1,0 +1,8 @@
+## client
+oauth.provider.github.client-id=1d8838ceb657fe17c108
+oauth.provider.github.client-secret=8cb208ef2fbbdcecb937252558745599064017d1
+oauth.provider.github.redirect-uri=http://localhost:8080/api/auth/github/callback
+## path
+oauth.provider.github.authorize-path=https://github.com/login/oauth/authorize
+oauth.provider.github.access-token-path=https://github.com/login/oauth/access_token
+oauth.provider.github.resource-path=https://api.github.com/user

--- a/backend/src/main/resources/sql/data.sql
+++ b/backend/src/main/resources/sql/data.sql
@@ -89,6 +89,40 @@ INSERT INTO dish_delivery (dish_id, delivery_code)
 VALUES (1, 'DL001');
 INSERT INTO dish_delivery (dish_id, delivery_code)
 VALUES (1, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (2, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (3, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (3, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (5, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (5, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (6, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (7, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (8, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (8, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (9, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (11, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (11, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (12, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (12, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (13, 'DL001');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (15, 'DL002');
+INSERT INTO dish_delivery (dish_id, delivery_code)
+VALUES (16, 'DL001');
 
 -- category : festival
 INSERT INTO category (section_id, category_name, is_festival)


### PR DESCRIPTION
## 🤷‍♂️ Description

- 요리 다중 조회시  배송정보가 누락되는 점 수정
- 배송 정보 관련 데이터 추가
- 브랜치를 잘 못 파서 다시 올립니다 ㅠㅠ


## 📝 Primary Commits

- [X] 요리 다중 조회시 배송정보 누락 오류 수정
- [X] 배송 정보 관련 데이터 추가 (`dish_delivery` 테이블)
- [X] API 정상 작동 확인


## 📷 Screenshots

- 요리 다중 조회 : `http://localhost:8080/api/dishes?section=뜨끈한-국물요리`
 
![image](https://user-images.githubusercontent.com/67811880/165816901-6f9da5af-20a2-4708-a3b7-423d0c2c19e1.png)

