### PR TITLE
[FE] 로그인 페이지 이동, 배송 정보 렌더링

### DIFF
--- a/frontend/sidedish/package-lock.json
+++ b/frontend/sidedish/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.3.4",
@@ -8002,6 +8003,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -13240,6 +13249,30 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -21768,6 +21801,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -25411,6 +25452,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/frontend/sidedish/package.json
+++ b/frontend/sidedish/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.3.4",

--- a/frontend/sidedish/src/index.js
+++ b/frontend/sidedish/src/index.js
@@ -1,6 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./view/App";
+import { BrowserRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(
+    <BrowserRouter>
+        <App />
+    </BrowserRouter>
+);

--- a/frontend/sidedish/src/view/App.jsx
+++ b/frontend/sidedish/src/view/App.jsx
@@ -1,43 +1,16 @@
 import GlobalStyle from "./GlobalStyle";
-import Header from "./header/Header";
-import BigSidedish from "./sidedish/BigSidedish";
-import SmallSidedish from "./sidedish/SmallSidedish";
-import Button2ShowAllCategory from "./sidedish/Button2ShowAllCategory";
-import { useState } from "react";
-
-const category = [
-    { title: "식탁을 풍성하게 하는 정갈한 밑반찬", section: "정갈한-밑반찬" },
-    { title: "정성이 담긴 뜨끈뜨끈 국물 요리", section: "뜨끈한-국물요리" },
-    { title: "모두가 좋아하는 든든한 메인 요리", section: "든든한-메인요리" },
-];
+import { Routes, Route } from "react-router-dom";
+import Home from "./Home";
+import Login from "./Login";
 
 function App() {
-    const [isBtnVisible, setBtnVisibility] = useState(true);
-    const [isAllCategoryVisible, setAllCategoryVisibility] = useState(false);
-    const btnClickEventHandler = () => {
-        setBtnVisibility(false);
-        setAllCategoryVisibility(true);
-    };
-
     return (
         <>
             <GlobalStyle />
-            <Header />
-            <BigSidedish />
-            <SmallSidedish isVisible category={category[0]} />
-            <Button2ShowAllCategory
-                text="모든 카테고리 보기"
-                isBtnVisible={isBtnVisible}
-                onClick={btnClickEventHandler}
-            />
-            <SmallSidedish
-                isVisible={isAllCategoryVisible}
-                category={category[1]}
-            />
-            <SmallSidedish
-                isVisible={isAllCategoryVisible}
-                category={category[2]}
-            />
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/login" element={<Login />} />
+            </Routes>
         </>
     );
 }

--- a/frontend/sidedish/src/view/GlobalStyle.jsx
+++ b/frontend/sidedish/src/view/GlobalStyle.jsx
@@ -15,6 +15,15 @@ const GlobalStyle = createGlobalStyle`
         outline: 0;
         background-color: transparent;
     }
+    svg {
+        color: black;
+        &:link,
+        &:visited,
+        &:hover,
+        &:active {
+            color: black;
+        }
+    }
 `;
 
 export default GlobalStyle;

--- a/frontend/sidedish/src/view/Home.jsx
+++ b/frontend/sidedish/src/view/Home.jsx
@@ -1,0 +1,43 @@
+import Header from "./header/Header";
+import BigSidedish from "./sidedish/BigSidedish";
+import SmallSidedish from "./sidedish/SmallSidedish";
+import Button2ShowAllCategory from "./sidedish/Button2ShowAllCategory";
+import { useState } from "react";
+
+const category = [
+    { title: "식탁을 풍성하게 하는 정갈한 밑반찬", section: "정갈한-밑반찬" },
+    { title: "정성이 담긴 뜨끈뜨끈 국물 요리", section: "뜨끈한-국물요리" },
+    { title: "모두가 좋아하는 든든한 메인 요리", section: "든든한-메인요리" },
+];
+
+function Home() {
+    const [isBtnVisible, setBtnVisibility] = useState(true);
+    const [isAllCategoryVisible, setAllCategoryVisibility] = useState(false);
+    const btnClickEventHandler = () => {
+        setBtnVisibility(false);
+        setAllCategoryVisibility(true);
+    };
+
+    return (
+        <>
+            <Header />
+            <BigSidedish />
+            <SmallSidedish isVisible category={category[0]} />
+            <Button2ShowAllCategory
+                text="모든 카테고리 보기"
+                isBtnVisible={isBtnVisible}
+                onClick={btnClickEventHandler}
+            />
+            <SmallSidedish
+                isVisible={isAllCategoryVisible}
+                category={category[1]}
+            />
+            <SmallSidedish
+                isVisible={isAllCategoryVisible}
+                category={category[2]}
+            />
+        </>
+    );
+}
+
+export default Home;

--- a/frontend/sidedish/src/view/Login.jsx
+++ b/frontend/sidedish/src/view/Login.jsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+
+function Login() {
+    return (
+        <Center>
+            <LoginButton>Login with GitHub</LoginButton>
+        </Center>
+    );
+}
+
+const Center = styled.div`
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #f1f3f5;
+`;
+
+const LoginButton = styled.button`
+    padding: 12px 80px;
+    background-color: #212529;
+    color: white;
+    font-size: 1.6rem;
+    border-radius: 10px;
+`;
+
+export default Login;

--- a/frontend/sidedish/src/view/Login.jsx
+++ b/frontend/sidedish/src/view/Login.jsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 function Login() {
     return (
         <Center>
-            <LoginButton>Login with GitHub</LoginButton>
+            <Link to="/api/auth/github">
+                <LoginButton>Login with GitHub</LoginButton>
+            </Link>
         </Center>
     );
 }

--- a/frontend/sidedish/src/view/header/Header.jsx
+++ b/frontend/sidedish/src/view/header/Header.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import {
     Wrapper,
     Container,
@@ -107,9 +108,8 @@ const icons = [
         </svg>
     </button>,
     <button>
-        <a href="/">
+        <Link to="/login">
             <svg
-                className="h-5 w-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"
@@ -120,7 +120,7 @@ const icons = [
                     clipRule="evenodd"
                 />
             </svg>
-        </a>
+        </Link>
     </button>,
     <button>
         <svg

--- a/frontend/sidedish/src/view/sidedish/SidedishCards.jsx
+++ b/frontend/sidedish/src/view/sidedish/SidedishCards.jsx
@@ -20,6 +20,7 @@ function SidedishCards({ dishes, isBigCards }) {
                 fixedPrice={dish.fixedPrice}
                 discountPrice={dish.discountPrice}
                 eventBadges={dish.discounts}
+                deliveries={dish.deliveries}
             />
         );
     });

--- a/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
+++ b/frontend/sidedish/src/view/sidedish/SmallSidedish.jsx
@@ -73,6 +73,7 @@ function SmallSidedish({ isVisible, category }) {
 
     const currSmallSidedishes = getCurrSmallSidedishes(page, smallSidedishes);
 
+    console.log(currSmallSidedishes);
     return (
         <Container>
             <SmallDishTitle>{title}</SmallDishTitle>

--- a/frontend/sidedish/src/view/sidedish/card/Card.jsx
+++ b/frontend/sidedish/src/view/sidedish/card/Card.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import {
+    DishCard,
     ImgWrapper,
     Img,
     TextContainer,
@@ -8,7 +10,25 @@ import {
     ClientPrice,
     OriginPrice,
     EventBadge,
+    DeliveryBadge,
 } from "./Card.style";
+import { getRandomKey } from "../../../utils";
+
+function Deliveries({ deliveries, isDeliveryBadgeVisible }) {
+    if (!deliveries || !deliveries.length) {
+        return;
+    }
+
+    const deliveryItems = deliveries.map((delivery) => (
+        <li key={getRandomKey()}>{delivery}</li>
+    ));
+
+    return (
+        <DeliveryBadge isVisible={isDeliveryBadgeVisible}>
+            {deliveryItems}
+        </DeliveryBadge>
+    );
+}
 
 function EventBadges({ eventBadges }) {
     if (!eventBadges.length) {
@@ -31,7 +51,10 @@ function Card({
     fixedPrice,
     discountPrice,
     eventBadges,
+    deliveries,
 }) {
+    const [isDeliveryBadgeVisible, setDeliveryBadgeVisibility] =
+        useState(false);
     const originPrice = (
         <OriginPrice>{fixedPrice.toLocaleString()}원</OriginPrice>
     );
@@ -40,8 +63,18 @@ function Card({
     );
     const isDiscounted = fixedPrice !== discountPrice;
 
+    const showDeliveryBadge = () => setDeliveryBadgeVisibility(true);
+    const hideDeliveryBadge = () => setDeliveryBadgeVisibility(false);
+
     return (
-        <li>
+        <DishCard
+            onMouseOver={showDeliveryBadge}
+            onMouseOut={hideDeliveryBadge}
+        >
+            <Deliveries
+                deliveries={deliveries}
+                isDeliveryBadgeVisible={isDeliveryBadgeVisible}
+            />
             <ImgWrapper>
                 <Img alt={title} src={image} />
             </ImgWrapper>
@@ -58,7 +91,7 @@ function Card({
                 </TextContainer>
                 <EventBadges eventBadges={eventBadges} />
             </div>
-        </li>
+        </DishCard>
     );
 }
 

--- a/frontend/sidedish/src/view/sidedish/card/Card.style.js
+++ b/frontend/sidedish/src/view/sidedish/card/Card.style.js
@@ -1,5 +1,9 @@
 import styled from "styled-components";
 
+const DishCard = styled.li`
+    position: relative;
+`;
+
 const ImgWrapper = styled.div`
     width: 100%
     height: 100%;
@@ -75,7 +79,23 @@ const EventBadge = styled.span`
             : ""};
 `;
 
+const DeliveryBadge = styled.div`
+    position: absolute;
+    top: 5%;
+    right: 5%;
+    border: 1px solid #1b1b1b;
+    border-radius: 10px;
+    background-color: rgba(248, 247, 247, 0.8);
+    display: ${(props) => (props.isVisible ? "flex" : "none")};
+    font-weight: 500;
+    font-size: 1.4rem;
+    padding: 5px 10px;
+    flex-direction: column;
+    gap: 6px;
+`;
+
 export {
+    DishCard,
     ImgWrapper,
     Img,
     TextContainer,
@@ -85,4 +105,5 @@ export {
     ClientPrice,
     OriginPrice,
     EventBadge,
+    DeliveryBadge,
 };


### PR DESCRIPTION
## 🤷‍♂️ Description

유저 아이콘을 클릭하면 로그인 페이지로 이동한다.
반찬 카드에 마우스를 올리면 배송 정보를 보여준다.

## 📝 Primary Commits

- [x] 유저 아이콘을 누르면 깃헙 로그인 버튼이 나타난다.
- [x] 로그인 버튼을 클릭하면 로그인 페이지로 이동한다.
- [x] 반찬 카드에 마우스를 올리면 배송 정보를 보여준다.  

## 📷 Screenshots

![마우스 호버 배송정보 노출](https://user-images.githubusercontent.com/62249058/165878837-36a7a042-36c8-4ec0-b4ea-009369603d5c.gif)

